### PR TITLE
change default cell color to white instead of clear

### DIFF
--- a/Todoing/ViewControllers/ItemsViewController.swift
+++ b/Todoing/ViewControllers/ItemsViewController.swift
@@ -32,7 +32,7 @@ class ItemsViewController: SwipeableTableViewController {
     override func viewWillAppear(_ animated: Bool) {
         title = selectedList!.name
         if let navBar = navigationController?.navigationBar {
-            if let listColor = UIColor(hex: selectedList!.color ?? "00000000") {
+            if let listColor = UIColor(hex: selectedList!.color ?? "FFFFFFFF") {
                 
                 navBar.largeTitleTextAttributes = [NSAttributedString.Key.foregroundColor : listColor]
                 searchBar.tintColor = listColor

--- a/Todoing/ViewControllers/ListsTableViewController.swift
+++ b/Todoing/ViewControllers/ListsTableViewController.swift
@@ -125,7 +125,7 @@ extension ListsTableViewController {
         // Setup Cell
         newCell.textLabel?.text = lists?[indexPath.row].name ?? "No lists added yet"
         newCell.accessoryType = .detailButton
-        if let cellColor = UIColor(hex: lists?[indexPath.row].color ?? "00000000") {
+        if let cellColor = UIColor(hex: lists?[indexPath.row].color ?? "FFFFFFFF") {
             newCell.backgroundColor = cellColor
 
             if cellColor.contrastRatio(withColor: .black) ?? 0 < 10 {


### PR DESCRIPTION
There was a bug where new lists were being assigned white tint colors for all future views and sub views. This was caused by the nil coalescing operator assigning clear as the default listColor. Changing the default listColor to white fixed all subView tint colors to be assigned black as normal.